### PR TITLE
Fix #1 - Unable to find js on prod build

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,8 +10,8 @@ import renderApp from './render-app'
 const app = express()
 
 app.use(compression())
-app.use(STATIC_PATH, express.static('dist'))
 app.use(STATIC_PATH, express.static('public'))
+app.use(STATIC_PATH, express.static('dist'))
 
 app.get('/', (req, res) => {
   res.send(renderApp(APP_NAME))

--- a/src/server/render-app.js
+++ b/src/server/render-app.js
@@ -12,7 +12,7 @@ const renderApp = (title: string) =>
   </head>
   <body>
     <div class="${APP_CONTAINER_CLASS}"></div>
-    <script src="${isProd ? STATIC_PATH : `http://localhost:${WDS_PORT}/dist/js/bundle.js`}"></script>
+    <script src="${isProd ? `${STATIC_PATH}/js/bundle.js` : `http://localhost:${WDS_PORT}/dist/js/bundle.js`}"></script>
   </body>
 </html>
 `


### PR DESCRIPTION
On production builds, the browser was unable to resolve the path to the
javascript, resulting in a dead app. This commit fixes the issue by
correctly specifying the path in the template that Express serves up.