### PR TITLE
Fix #3 - Fix broken Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,6 @@
 [options]
 suppress_comment= \\(.\\|\n\\)*\\flow-disable-next-line
+
+# An awkward fix for a bug
+[ignore]
+<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/src/rules/media-has-caption.js

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "start": "yarn dev:start",
+    "test": "yarn lint && yarn flow && yarn test:unit",
     "dev:start": "nodemon -e js,jsx --ignore lib --ignore dist --exec babel-node src/server",
     "dev:wds": "webpack-dev-server --progress",
     "dockerize": "docker build -t build-monitor . && docker run -p 80:8000 build-monitor",
@@ -25,7 +26,6 @@
     "prod:start": "cross-env NODE_ENV=production pm2 start lib/server && pm2 logs",
     "prod:stop": "pm2 delete server",
     "lint": "eslint src webpack.config.babel.js --ext .js,.jsx",
-    "test": "yarn lint && yarn test:unit",
     "prepush": "yarn test && yarn prod:build",
     "test:unit": "tape src/**/*.test.js | tap-dot"
   },

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -20,6 +20,7 @@ const wrapApp = AppComponent => (
 ReactDOM.render(wrapApp(App), rootEl)
 
 if (module.hot) {
+  // flow-disable-next-line
   module.hot.accept('./app', () => {
     // eslint-disable-next-line global-require
     const NextApp = require('./app').default


### PR DESCRIPTION
Running `yarn flow` gives a weird error, very similar to
[this](https://github.com/verekia/js-stack-walkthrough/issues/5).

This commit resolves the issue, but it seems like an awkward, brittle
overly specific patch. I'm not sure what the more general solution would
be, so I'm going with this fix for now. At least it gets Flow typechecks
up and running.