### PR TITLE
Handle multiple projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
 [![Build Status](https://travis-ci.org/BillyZac/build-monitor.svg?branch=master)](https://travis-ci.org/BillyZac/build-monitor)
 
-## Install stuff
+## Install dependencies
+```
 yarn
+```
 
 ## Dev: start server and client
+```
 yarn start
 yarn dev:wds
+```
 
 ## Build and run a Docker image locally
+```
 yarn dockerize
+```
 Visit http://localhost/
 
+
 ## Prod
+```
 yarn prod:build
 yarn prod:start
 yarn prod:stop
+```
+
+## Configuring projects
+The app will list build status for any repository listed in `PROJECTS` in `src/shared/config.js`. (This hard-coded list will be replaced by [a user-editable list at some point](https://github.com/BillyZac/build-monitor/issues/23).)
 
 ## Deployment
 The current deployment strategy works like this:
@@ -31,14 +43,3 @@ If the `now` dev deployment looks good, upgrade it to prod with `now alias https
 Using Compat, which gives a linting warning if you try to use syntax not supported by all browsers with >1% market share.
 
 Using a Babel plugin called flow-react-proptypes, which automatically generates PropTypes from Flow annotations for your React components.
-
-
-
-
-
-
-
-
-
-
-:)

--- a/src/client/app.jsx
+++ b/src/client/app.jsx
@@ -1,53 +1,43 @@
 import React from 'react'
 import moment from 'moment'
-import fetchRepoStatus from './services/fetchRepoStatus'
+import fetchRepoStatuses from './services/fetchRepoStatuses'
 import TimeStamp from './components/TimeStamp'
+import ProjectStatus from './components/ProjectStatus'
+import { PROJECTS } from '../shared/config'
 
 class App extends React.Component {
   constructor() {
     super()
     this.state = {
-      repo: 'buildit/bookit-web',
-      status: {},
+      repos: PROJECTS,
       lastUpdated: {},
+      projectStatuses: [],
     }
   }
 
   componentDidMount() {
-    const POLLING_INTERVAL = 10000 // milliseconds
+    const POLLING_INTERVAL = 1000 // milliseconds
     setInterval(() => {
-      fetchRepoStatus(this.state.repo)
-        .then((status) => {
+      fetchRepoStatuses(this.state.repos)
+        .then((projectStatuses) => {
           const lastUpdated = moment()
-          this.setState({ lastUpdated, status })
+          this.setState({ projectStatuses, lastUpdated })
+        })
+        .catch((err) => {
+          console.log(err.message)
         })
     }, POLLING_INTERVAL)
   }
 
   render() {
-    const { status, lastUpdated } = this.state
+    const { lastUpdated, projectStatuses } = this.state
+
     return (
       <div>
         <div className="statusList">
-          <div style={{
-            display: 'flex',
-            alignItems: 'baseline',
-          }}
-          >
-            <span style={{
-              margin: '0 0.5rem',
-              width: '0.7rem',
-              height: '0.7rem',
-              display: 'inline-block',
-              background: status.result ? '#37de0d' : '#ee1497',
-              borderRadius: '50%',
-            }}
-            />
-            <span style={{
-              margin: '0',
-            }}
-            >Bookit web</span>
-          </div>
+          { projectStatuses.map(
+            status => <ProjectStatus name={status.name} buildResult={status.result} />,
+          )}
         </div>
         <TimeStamp lastUpdated={lastUpdated} />
       </div>

--- a/src/client/components/ProjectStatus.jsx
+++ b/src/client/components/ProjectStatus.jsx
@@ -1,0 +1,32 @@
+// @flow
+
+import React from 'react'
+
+type Props = {
+  name: string,
+  buildResult: boolean,
+}
+
+const Repo = ({ name, buildResult }: Props) => (
+  <div style={{
+    display: 'flex',
+    alignItems: 'baseline',
+  }}
+  >
+    <span style={{
+      margin: '0 0.5rem',
+      width: '0.7rem',
+      height: '0.7rem',
+      display: 'inline-block',
+      background: buildResult ? '#37de0d' : '#ee1497',
+      borderRadius: '50%',
+    }}
+    />
+    <span style={{
+      margin: '0',
+    }}
+    >{ name }</span>
+  </div>
+  )
+
+export default Repo

--- a/src/client/services/fetchRepoStatus.js
+++ b/src/client/services/fetchRepoStatus.js
@@ -5,7 +5,9 @@ const fetchRepoStatus = repo => new Promise((resolve, reject) => {
 
   fetchBuilds(url)
     .then((builds) => {
-      resolve(builds[0])
+      resolve(Object.assign({
+        name: repo,
+      }, builds[0]))
     })
     .catch((err) => {
       reject(err)

--- a/src/client/services/fetchRepoStatus.test.js
+++ b/src/client/services/fetchRepoStatus.test.js
@@ -11,6 +11,7 @@ test('Builds fetcher correctly maps the build information', (t) => {
   fetchRepoStatus('mockGithubUser/mock-repo-name')
     .then((currentBuildStatus) => {
       const desiredResult = {
+        name: 'mockGithubUser/mock-repo-name',
         id: 123,
         message: 'Add stuff',
         number: 639,

--- a/src/client/services/fetchRepoStatuses.js
+++ b/src/client/services/fetchRepoStatuses.js
@@ -1,0 +1,7 @@
+const fetchRepoStatus = require('./fetchRepoStatus')
+
+const fetchRepoStatuses = repos => Promise.all(
+  repos.map(fetchRepoStatus),
+)
+
+module.exports = fetchRepoStatuses

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -8,3 +8,8 @@ export const WDS_PORT = 7000
 
 export const APP_CONTAINER_CLASS = 'js-app'
 export const APP_CONTAINER_SELECTOR = `.${APP_CONTAINER_CLASS}`
+
+export const PROJECTS = [
+  'buildit/bookit-web',
+  'buildit/bookit-server',
+]


### PR DESCRIPTION
We can handle multiple projects by specifying the repository names in
the `PROJECTS` in the config file. This should be made user-editable at
some point, but I think it does the trick for the moment.

Also:
- Added component for displaying repo build info