### PR TITLE
Improve deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 lib
 dist
 test-src
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
 
 deploy:
   provider: script
-  script: scripts/deploy.sh
+  script: scripts/deploy.sh $ZEIT_NOW_TOKEN

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,2 +1,7 @@
-echo "Deploying with Zeit Now"
-now --token $ZEIT_NOW_TOKEN --docker --public
+if [ $1 ]
+then
+  echo "Deploying with Zeit Now..."
+  now --token $1 --docker --public
+else
+  echo "Please supply a Zeit Now token as the first argument to the script."
+fi


### PR DESCRIPTION
The script now takes the Zeit Now token as an argument. This makes it
easier to run from the command line manually.